### PR TITLE
Fix: Call to a member function toArray() on array

### DIFF
--- a/src/Laradump.php
+++ b/src/Laradump.php
@@ -91,7 +91,7 @@ class Laradump
                 'model' => $model,
                 'view' => view('laradump::model', [
                     'model' => $model,
-                    'dump' => VarDump::customDumper($models->toArray()),
+                    'dump' => VarDump::customDumper($model->toArray()),
                     'relation' => VarDump::customDumper($model->getRelations()),
                     'call' => $called_by,
                 ])->render(),


### PR DESCRIPTION
It was throwing this error on laradump()->model(User::find(1));