### PR TITLE
Handle non model value normally in laradump()->model() method

### DIFF
--- a/src/Laradump.php
+++ b/src/Laradump.php
@@ -84,6 +84,11 @@ class Laradump
     public function model(...$models)
     {
         foreach ($models as $model) {
+            if (! $model instanceof \Illuminate\Database\Eloquent\Model) {
+                $this->dump($model);
+                continue;
+            }
+            
             $called_by = StackTracer::createTrace();
 
             $this->sendRequest([


### PR DESCRIPTION
Currently if we pass values other than model instance to` laradump()->model()`, for example `laradump()->model('Test', [1, 2, 3], App\Models\User::first()`) , it throws exception. How about passing those values to `dump()` method?
